### PR TITLE
Fix average_win, most_goals, & fewest_goals

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -16,7 +16,7 @@ class StatTracker
     stats_tracker = StatTracker.new(games_input, teams_input, game_teams_input)
   end
 #------------------------------------Game Statistics------------------------------------
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def highest_total_score
     highest_scoring_game = @games.max_by do |game|
       game[:away_goals].to_i + game[:home_goals].to_i
@@ -24,7 +24,7 @@ class StatTracker
     highest_scoring_game[:away_goals].to_i + highest_scoring_game[:home_goals].to_i
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def lowest_total_score
     lowest_scoring_game = @games.min_by do |game|
       game[:away_goals].to_i + game[:home_goals].to_i
@@ -38,7 +38,7 @@ class StatTracker
     @games.count
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   # Recommend combining percentage_ties, percentage_home_wins, percentage_visitor_wins methods using mixins or (look at count iterator)
   def percentage_home_wins
     home_wins = 0
@@ -50,7 +50,7 @@ class StatTracker
     (home_wins.to_f / @games.count).round(2)
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   # Recommend combining percentage_ties, percentage_home_wins, percentage_visitor_wins methods using mixins or (look at count iterator)
   def percentage_visitor_wins
     visitor_wins = 0
@@ -62,7 +62,7 @@ class StatTracker
     (visitor_wins.to_f / @games.count).round(2)
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   # Recommend combining percentage_ties, percentage_home_wins, percentage_visitor_wins methods using mixins or (look at count iterator)
   def percentage_ties
     ties = 0
@@ -74,12 +74,12 @@ class StatTracker
     (ties.to_f / @games.count).round(2)
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def count_of_games_by_season
     @games[:season].tally
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def average_goals_per_game
     total_goals = @games[:away_goals].map(&:to_i).sum.to_f + @games[:home_goals].map(&:to_i).sum
     (total_goals / @games.size).round(2)
@@ -98,7 +98,7 @@ class StatTracker
     goals_per_season
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def average_goals_by_season
     season_goal_averages = Hash.new
     total_goals_per_season.each do |season, goals|
@@ -147,7 +147,7 @@ class StatTracker
   end
 
   # Helper method is used in average_scores_for_all_visitors & average_scores_for_all_home_teams
-  # Recomend refactor by mixin 'calculator'
+  # Recommend refactor by mixin 'calculator'
   def average_score_per_game(game_teams_selection)
     goals = game_teams_selection.sum {|game| game[:goals].to_f}
     # You need to / 2. The game_teams CSV has 2 lines to represent one game.
@@ -156,7 +156,7 @@ class StatTracker
   end
 
   # Helper method is used in average_scores_for_all_visitors
-  # Recomend refactor as similar to method home_games_by_team_id & winning_as_coach
+  # Recommend refactor as similar to method home_games_by_team_id & winning_as_coach
   def away_games_by_team_id
     away_games_list = @game_teams.find_all {|game| game[:hoa] == "away"}
     away_games_hash = Hash.new([])
@@ -194,7 +194,7 @@ class StatTracker
     @home_hash
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def highest_scoring_visitor
     average_scores_for_all_visitors
     highest_scoring_team = @teams.find do |team|
@@ -203,7 +203,7 @@ class StatTracker
     highest_scoring_team[:teamname]
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def highest_scoring_home_team
     average_scores_for_all_home_teams
     highest_scoring_team = @teams.find do |team|
@@ -212,7 +212,7 @@ class StatTracker
     highest_scoring_team[:teamname]
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def lowest_scoring_visitor
     average_scores_for_all_visitors
     lowest_scoring_team = @teams.find do |team|
@@ -221,7 +221,7 @@ class StatTracker
     lowest_scoring_team[:teamname]
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def lowest_scoring_home_team
     average_scores_for_all_home_teams
     highest_scoring_team = @teams.find do |team|
@@ -283,7 +283,7 @@ class StatTracker
   end
 
   # Helper method is used in most_tackles & fewest_tackles
-  # Recomend refactor into 2 methods. 1. Selects games in a given season. 2. Finds tackles in that set of games.
+  # Recommend refactor into 2 methods. 1. Selects games in a given season. 2. Finds tackles in that set of games.
   def tackles_by_team(season)
     games_by_season
     games_in_select_season = @games_by_season_hash[season]
@@ -296,7 +296,7 @@ class StatTracker
     @tackles_counter
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def most_tackles(season)
     tackles_by_team(season)
     team_with_most_tackles = @teams.find do |team|
@@ -305,7 +305,7 @@ class StatTracker
     team_with_most_tackles[:teamname]
   end
 
-  # Origional method from Iteration 2
+  # Original method from Iteration 2
   def fewest_tackles(season)
     tackles_by_team(season)
     team_with_least_tackles = @teams.find do |team|

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -327,15 +327,33 @@ class StatTracker
     team_info_hash
   end
 
-  # Original method from Iteration 2
-  # Returns Hash with
-  def best_season(team_id)
+  # Helper method is used in best_season & worst_season
+  def games_by_team_by_season(team_id)
     games_by_season
-    @games_of_team_by_season = Hash.new([])
+    @games_by_team_by_season_hash = Hash.new([])
     @games_by_season_hash.each do |season, games_array|
-      @games_of_team_by_season[season] += average_score_per_game([@game_teams.find_all {|game| team_id == game[:team_id] && games_array.include?(game[:game_id])}])
+      @games_by_team_by_season_hash[season] += @game_teams.find_all {|game| team_id == game[:team_id] && games_array.include?(game[:game_id])}
     end
-    @games_of_team_by_season
+    @games_by_team_by_season_hash
+  end
+
+  # Original method from Iteration 2
+  def best_season(team_id)
+    games_by_team_by_season(team_id)
+    game_wins_by_team_by_season = Hash.new
+    @games_by_team_by_season_hash.each do |season, games_by_team|
+      game_wins_by_team_by_season[season] = ((games_by_team.count {|game| game[:result] == "WIN"}.to_f/games_by_team.length.to_f) * 100).round(2)
+    end
+    game_wins_by_team_by_season.key(game_wins_by_team_by_season.values.max)
+  end
+
+  def worst_season(team_id)
+    games_by_team_by_season(team_id)
+    game_wins_by_team_by_season = Hash.new
+    @games_by_team_by_season_hash.each do |season, games_by_team|
+      game_wins_by_team_by_season[season] = ((games_by_team.count {|game| game[:result] == "WIN"}.to_f/games_by_team.length.to_f) * 100).round(2)
+    end
+    game_wins_by_team_by_season.key(game_wins_by_team_by_season.values.min)
   end
 
 
@@ -374,7 +392,7 @@ class StatTracker
   # Helper method is used in favorite_opponent & rival
   # Can be further refactored into more helper methods
   def opponent_win_loss(team_id)
-    # Keys of team_games_opponents hould be game_ids of games team is involved in
+    # Keys of team_games_opponents should be game_ids of games team is involved in
     # Values of team_games_opponents should be the team_id of their opponent in that game
     team_games_opponents = {}
     @games.each do |game|

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -325,12 +325,14 @@ class StatTracker
 
   # Original method from Iteration 2
   def average_win_percentage(team_id)
+    games_by_team
     games_to_check = @games_by_team_hash[team_id]
     (games_to_check.count {|game| game[:result] == 'WIN'}.to_f / games_to_check.length.to_f).round(2)
   end
 
   # Original method from Iteration 2
   def most_goals_scored(team_id)
+    games_by_team
     games_to_check = @games_by_team_hash[team_id]
     game_most_goals = games_to_check.max_by {|game| game[:goals].to_i}
     game_most_goals[:goals].to_i
@@ -338,6 +340,7 @@ class StatTracker
 
   # Original method from Iteration 2
   def fewest_goals_scored(team_id)
+    games_by_team
     games_to_check = @games_by_team_hash[team_id]
     game_least_goals = games_to_check.min_by {|game| game[:goals].to_i}
     game_least_goals[:goals].to_i

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -314,6 +314,31 @@ class StatTracker
     team_with_least_tackles[:teamname]
   end
 #------------------------------------Team Statistics------------------------------------
+  # Original method from Iteration 2
+  def team_info
+    team_info_hash = Hash.new([])
+    @teams.each do |team|
+      team_info_hash['team_id'] += [team[:team_id]]
+      team_info_hash['franchise_id'] += [team[:franchiseid]]
+      team_info_hash['team_name'] += [team[:teamname]]
+      team_info_hash['abbreviation'] += [team[:abbreviation]]
+      team_info_hash['link'] += [team[:link]]
+    end
+    team_info_hash
+  end
+
+  # Original method from Iteration 2
+  # Returns Hash with
+  def best_season(team_id)
+    games_by_season
+    @games_of_team_by_season = Hash.new([])
+    @games_by_season_hash.each do |season, games_array|
+      @games_of_team_by_season[season] += average_score_per_game([@game_teams.find_all {|game| team_id == game[:team_id] && games_array.include?(game[:game_id])}])
+    end
+    @games_of_team_by_season
+  end
+
+
   # Helper method is used in average_win_percentage & most_goals_scored & fewest_goals_scored
   def games_by_team
     @games_by_team_hash = Hash.new([])

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -203,11 +203,10 @@ RSpec.describe StatTracker do
     end
 
     it "#best_season" do
-      binding.pry
       expect(@stat_tracker.best_season("6")).to eq "20132014"
     end
 
-    xit "#worst_season" do
+    it "#worst_season" do
       expect(@stat_tracker.worst_season("6")).to eq "20142015"
     end
 

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -192,6 +192,25 @@ RSpec.describe StatTracker do
   end
 
   context "Team Statistics" do
+    it "#team_info" do
+    expected = {
+      "team_id" => "18",
+      "franchise_id" => "34",
+      "team_name" => "Minnesota United FC",
+      "abbreviation" => "MIN",
+      "link" => "/api/v1/teams/18"
+    }
+    end
+
+    it "#best_season" do
+      binding.pry
+      expect(@stat_tracker.best_season("6")).to eq "20132014"
+    end
+
+    xit "#worst_season" do
+      expect(@stat_tracker.worst_season("6")).to eq "20142015"
+    end
+
     it "#helper games_by_team" do
       expect(@stat_tracker.games_by_team.keys.length).to eq(@stat_tracker.teams[:team_id].length)
     end


### PR DESCRIPTION
This PR will fix:
3 methods from iteration 2 (average_win_percentage, most_goals_scored, & fewest_goals_scored)
Testing is showing 100.0% coverage for all methods
Issue was games_by_team was not run for each method. Methods passed in stat_tracker_spec but failed in spec_harness. Issue now corrected.

(2nd PR in this branch. To add team_info, games_by_team_by_season, best_season, worst_season. Sorry for the confusion)
This PR will add:
3 methods from iteration 2 (add team_info, best_season, worst_season)
1 helper method (games_by_team_by_season)
Testing is showing 97.78%. Test for games_by_team_by_season still WIP.
