### PR TITLE
Add team_games_opponents and avg_goals_per_game helper methods

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -244,8 +244,8 @@ class StatTracker
     season_game_teams = @game_teams.find_all {|row| row[:game_id].start_with?(season[0..3])}
   end
 
-  # Original method from Iteration 2
-  def most_accurate_team(season)
+  # Helper method used in most_accurate_team and least_accurate_team
+  def season_shots_to_goals(season)
     season_game_teams = season_game_teams(season)
     shots_to_goals = Hash.new(0)
     season_shots = Hash.new(0)
@@ -253,6 +253,12 @@ class StatTracker
     season_game_teams.each { |row| season_goals[row[:team_id]] += row[:goals].to_f }
     season_game_teams.each { |row| season_shots[row[:team_id]] += row[:shots].to_f }
     season_shots.keys.each {|team_id| shots_to_goals[team_id] = season_shots[team_id]/season_goals[team_id]}
+    shots_to_goals
+  end
+
+  # Original method from Iteration 2
+  def most_accurate_team(season)
+    shots_to_goals = season_shots_to_goals(season)
     most_accurate_team_id = (shots_to_goals.min_by {|team_id, ratio| ratio})[0]
     most_accurate_team = @teams.find do |team|
       team[:team_id] == most_accurate_team_id
@@ -262,13 +268,7 @@ class StatTracker
 
   # Original method from Iteration 2
   def least_accurate_team(season)
-    season_game_teams = season_game_teams(season)
-    shots_to_goals = Hash.new(0)
-    season_shots = Hash.new(0)
-    season_goals = Hash.new(0)
-    season_game_teams.each { |row| season_goals[row[:team_id]] += row[:goals].to_f }
-    season_game_teams.each { |row| season_shots[row[:team_id]] += row[:shots].to_f }
-    season_shots.keys.each {|team_id| shots_to_goals[team_id] = season_shots[team_id]/season_goals[team_id]}
+    shots_to_goals = season_shots_to_goals(season)
     least_accurate_team_id = (shots_to_goals.max_by {|team_id, ratio| ratio})[0]
     least_accurate_team = @teams.find do |team|
       team[:team_id] == least_accurate_team_id
@@ -346,12 +346,11 @@ class StatTracker
     game_least_goals[:goals].to_i
   end
 
-  # Helper method is used in favorite_opponent & rival
-  # Can be further refactored into more helper methods
-  def opponent_win_loss(team_id)
-    # Keys of team_games_opponents hould be game_ids of games team is involved in
-    # Values of team_games_opponents should be the team_id of their opponent in that game
+  # Helper method is used in opponent_win_loss
+  def team_games_opponents(team_id)
     team_games_opponents = {}
+    # Keys of team_games_opponents should be game_ids of games team is involved in
+    # Values of team_games_opponents should be the team_id of their opponent in that game
     @games.each do |game|
       if game[:away_team_id] == team_id
         team_games_opponents[game[:game_id]] = game[:home_team_id]
@@ -359,7 +358,12 @@ class StatTracker
         team_games_opponents[game[:game_id]] = game[:away_team_id]
       end
     end
+    team_games_opponents
+  end
 
+  # Helper method is used in favorite_opponent & rival
+  def opponent_win_loss(team_id)
+    team_games_opponents = team_games_opponents(team_id)
     # Keys of opponent_win_loss should be the team_id of their opponents
     # Values of opponent_win_loss should be an array with 1st element being wins, 2nd element being losses
     opponent_win_loss = {}

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -165,6 +165,10 @@ RSpec.describe StatTracker do
       expect(@stat_tracker.season_game_teams("20132014")[0]).to be_a(CSV::Row)
     end
 
+    it "#helper season_shots_to_goals" do
+      expect(@stat_tracker.season_shots_to_goals("20132014")).to be_a(Hash)
+    end
+
     it "#most_accurate_team" do
       expect(@stat_tracker.most_accurate_team("20132014")).to eq("Real Salt Lake")
       expect(@stat_tracker.most_accurate_team("20142015")).to eq("Toronto FC")
@@ -210,6 +214,10 @@ RSpec.describe StatTracker do
 
     it "#fewest_goals_scored" do
       expect(@stat_tracker.fewest_goals_scored("18")).to eq 0
+    end
+
+    it "#helper team_games_opponents" do
+      expect(@stat_tracker.team_games_opponents("18")).to be_a(Hash)
     end
 
     it "#helper opponent_win_loss" do


### PR DESCRIPTION
This PR will: 

- Add team_games_opponents and avg_goals_per_game helper methods
- team_games_opponents is used in opponent_win_loss helper method
- avg_goals_per_game is used in most_accurate_team and least_accurate_team
